### PR TITLE
Employee Management Page - Data Retrieval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@emotion/styled": "^11.13.0",
         "@mui/icons-material": "^6.0.2",
         "@mui/material": "^6.0.0",
+        "@tanstack/react-query": "^5.59.0",
+        "@tanstack/react-query-devtools": "^5.59.0",
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",
         "ag-grid-community": "^32.2.0",
         "ag-grid-react": "^32.2.0",
@@ -1671,6 +1673,59 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.59.0.tgz",
+      "integrity": "sha512-WGD8uIhX6/deH/tkZqPNcRyAhDUqs729bWKoByYHSogcshXfFbppOdTER5+qY7mFvu8KEFJwT0nxr8RfPTVh0Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.58.0.tgz",
+      "integrity": "sha512-iFdQEFXaYYxqgrv63ots+65FGI+tNp5ZS5PdMU1DWisxk3fez5HG3FyVlbUva+RdYS5hSLbxZ9aw3yEs97GNTw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.59.0.tgz",
+      "integrity": "sha512-YDXp3OORbYR+8HNQx+lf4F73NoiCmCcSvZvgxE29OifmQFk0sBlO26NWLHpcNERo92tVk3w+JQ53/vkcRUY1hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.59.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.59.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.59.0.tgz",
+      "integrity": "sha512-Kz7577FQGU8qmJxROIT/aOwmkTcxfBqgTP6r1AIvuJxVMVHPkp8eQxWQ7BnfBsy/KTJHiV9vMtRVo1+R1tB3vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.58.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.59.0",
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^6.0.2",
     "@mui/material": "^6.0.0",
+    "@tanstack/react-query": "^5.59.0",
+    "@tanstack/react-query-devtools": "^5.59.0",
     "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "ag-grid-community": "^32.2.0",
     "ag-grid-react": "^32.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,56 +8,69 @@ import Layout from "./pages/Layout";
 import { AuthProvider } from "./hooks/useAuth";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+    },
+  },
+});
 
 const App = () => {
   return (
-    <AuthProvider>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route path="/login" element={<Login />} />
-          <Route
-            path="/home"
-            element={
-              <ProtectedRoute>
-                <Home />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/admin"
-            element={
-              <ProtectedRoute>
-                <Admin />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/patients"
-            element={
-              <ProtectedRoute>
-                <Patients />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/employees"
-            element={
-              <ProtectedRoute>
-                <Employees />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/in-service"
-            element={
-              <ProtectedRoute>
-                <InService />
-              </ProtectedRoute>
-            }
-          />
-        </Route>
-      </Routes>
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReactQueryDevtools />
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route path="/login" element={<Login />} />
+            <Route
+              path="/home"
+              element={
+                <ProtectedRoute>
+                  <Home />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin"
+              element={
+                <ProtectedRoute>
+                  <Admin />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/patients"
+              element={
+                <ProtectedRoute>
+                  <Patients />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/employees"
+              element={
+                <ProtectedRoute>
+                  <Employees />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/in-service"
+              element={
+                <ProtectedRoute>
+                  <InService />
+                </ProtectedRoute>
+              }
+            />
+          </Route>
+        </Routes>
+      </AuthProvider>
+    </QueryClientProvider>
   );
 };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,6 @@ import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -18,7 +17,6 @@ const queryClient = new QueryClient({
     },
   },
 });
-
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
@@ -73,5 +71,4 @@ const App = () => {
     </QueryClientProvider>
   );
 };
-
 export default App;

--- a/src/pages/Employees.jsx
+++ b/src/pages/Employees.jsx
@@ -1,77 +1,20 @@
-import { useState } from "react";
 import { AgGridReact } from "ag-grid-react";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
+import { getEployees } from "../services/apiEmployees";
+import { useQuery } from "@tanstack/react-query";
 
 const Employees = () => {
-  const [rowData] = useState([
-    {
-      employeeType: "Clinician",
-      clinicianName: "PATRICIA EPIE",
-      clinicianEmailId: "epipat.pe@gmail.com",
-      assigned: 6,
-      onGoing: 1,
-      completed: 0,
-      reOpen: 0,
-      total: 7,
-      lastLogin: "17-May-2023 17:36:36",
-    },
-    {
-      employeeType: "Clinician",
-      clinicianName: "YUDI PATEL, PT",
-      clinicianEmailId: "rehabexpertsinc15@gmail.com",
-      assigned: 0,
-      onGoing: 1,
-      completed: 0,
-      reOpen: 0,
-      total: 1,
-      lastLogin: "28-Oct-2022 11:56:18",
-    },
-    {
-      employeeType: "Clinician",
-      clinicianName: "Fabian Ogala",
-      clinicianEmailId: "ogalaf@yahoo.com",
-      assigned: 0,
-      onGoing: 2,
-      completed: 2,
-      reOpen: 0,
-      total: 4,
-      lastLogin: "3-Feb-2023 17:48:22",
-    },
-    {
-      employeeType: "Clinician",
-      clinicianName: "Dionne Staten",
-      clinicianEmailId: "dionnestaten@yahoo.com",
-      assigned: 2,
-      onGoing: 2,
-      completed: 41,
-      reOpen: 1,
-      total: 46,
-      lastLogin: "25-Jul-2024 14:55:12",
-    },
-    {
-      employeeType: "Clinician",
-      clinicianName: "Demo Clinician",
-      clinicianEmailId: "demo@yahoo.com",
-      assigned: 0,
-      onGoing: 0,
-      completed: 0,
-      reOpen: 0,
-      total: 0,
-      lastLogin: "25-Jul-2024 14:55:12",
-    },
-    {
-      employeeType: "Clinician",
-      clinicianName: "Praise Udjue",
-      clinicianEmailId: "myworldofpraise.pu@gmail.com",
-      assigned: 1,
-      onGoing: 2,
-      completed: 7,
-      reOpen: 0,
-      total: 10,
-      lastLogin: "25-Jul-202414:48:24",
-    },
-  ]);
+  const {
+    isPending,
+    data: patients,
+    error,
+  } = useQuery({
+    queryKey: ["employees"],
+    queryFn: getEployees,
+  });
+
+  const [rowData] = [patients];
 
   const columnDefs = [
     { field: "employeeType", headerName: "Employee Type", flex: 1 },
@@ -93,6 +36,7 @@ const Employees = () => {
     { field: "lastLogin", headerName: "Last Login", flex: 1 },
   ];
 
+  if (isPending) return "loading...";
   return (
     <div>
       <h2>Employee Management</h2>

--- a/src/pages/Employees.jsx
+++ b/src/pages/Employees.jsx
@@ -37,6 +37,8 @@ const Employees = () => {
   ];
 
   if (isPending) return "loading...";
+  if (!patients) return "No Employee records";
+
   return (
     <div>
       <h2>Employee Management</h2>

--- a/src/pages/Employees.jsx
+++ b/src/pages/Employees.jsx
@@ -7,14 +7,14 @@ import { useQuery } from "@tanstack/react-query";
 const Employees = () => {
   const {
     isPending,
-    data: patients,
+    data: employees,
     error,
   } = useQuery({
     queryKey: ["employees"],
     queryFn: getEployees,
   });
 
-  const [rowData] = [patients];
+  const [rowData] = [employees];
 
   const columnDefs = [
     { field: "employeeType", headerName: "Employee Type", flex: 1 },
@@ -37,7 +37,7 @@ const Employees = () => {
   ];
 
   if (isPending) return "loading...";
-  if (!patients) return "No Employee records";
+  if (!employees) return "No Employee records";
 
   return (
     <div>

--- a/src/pages/Employees.jsx
+++ b/src/pages/Employees.jsx
@@ -3,7 +3,6 @@ import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
 import { getEployees } from "../services/apiEmployees";
 import { useQuery } from "@tanstack/react-query";
-
 const Employees = () => {
   const {
     isPending,
@@ -13,9 +12,7 @@ const Employees = () => {
     queryKey: ["employees"],
     queryFn: getEployees,
   });
-
   const [rowData] = [employees];
-
   const columnDefs = [
     { field: "employeeType", headerName: "Employee Type", flex: 1 },
     {
@@ -35,10 +32,8 @@ const Employees = () => {
     { field: "total", headerName: "Total", flex: 1 },
     { field: "lastLogin", headerName: "Last Login", flex: 1 },
   ];
-
   if (isPending) return "loading...";
   if (!employees) return "No Employee records";
-
   return (
     <div>
       <h2>Employee Management</h2>
@@ -48,5 +43,4 @@ const Employees = () => {
     </div>
   );
 };
-
 export default Employees;

--- a/src/pages/Patients.jsx
+++ b/src/pages/Patients.jsx
@@ -51,7 +51,6 @@ const Patients = () => {
       }, 5);
     },
   };
-
   return (
     <div>
       <h2>Patient Management</h2>
@@ -68,5 +67,4 @@ const Patients = () => {
     </div>
   );
 };
-
 export default Patients;

--- a/src/services/apiEmployees.js
+++ b/src/services/apiEmployees.js
@@ -1,8 +1,8 @@
 import axios from "axios";
 export async function getEployees() {
-  const { data, error } = await axios.get(
-    "https://v5bgbb7bq3.execute-api.us-east-1.amazonaws.com/development/employees"
-  );
+  const url =
+    "https://v5bgbb7bq3.execute-api.us-east-1.amazonaws.com/development/employees";
+  const { data, error } = await axios.get(url);
   if (error) {
     console.log(error);
     throw new Error("Employees could not be loaded");

--- a/src/services/apiEmployees.js
+++ b/src/services/apiEmployees.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+export async function getEployees() {
+  const { data, error } = await axios.get(
+    "https://v5bgbb7bq3.execute-api.us-east-1.amazonaws.com/development/employees"
+  );
+  if (error) {
+    console.log(error);
+    throw new Error("Employees could not be loaded");
+  }
+  return data;
+}

--- a/src/services/apiEmployees.js
+++ b/src/services/apiEmployees.js
@@ -2,10 +2,6 @@ import axios from "axios";
 export async function getEployees() {
   const url =
     "https://v5bgbb7bq3.execute-api.us-east-1.amazonaws.com/development/employees";
-  const { data, error } = await axios.get(url);
-  if (error) {
-    console.log(error);
-    throw new Error("Employees could not be loaded");
-  }
+  const { data } = await axios.get(url);
   return data;
 }


### PR DESCRIPTION
As A User
I want to view a list of Employees on the Employee Management Page that were retrieved from the “/employees” endpoint

So that data from the endpoint is viewable instead of hard coded data

 
Using Tanstack Query - request all employees from the “/employee” endpoint, ensuring that the loading and error states and messages are returned. The handling of errors is out of scope

While data is being retrieved, display a loading message “loading…” The AG-Grid should not be visible until the data has been returned from the endpoint. (You can check the “data” property of the response. If the request was successful, the “data” property will contain the list of employees)
